### PR TITLE
flit 3.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.0" %}
+{% set version = "3.3.0" %}
 
 package:
   name: flit-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flit/flit-{{ version }}.tar.gz
-  sha256: 592464c9268bbacec9bc67b5a3ae62e6e090aeec1563e69501df338a1728e551
+  sha256: 65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57
   folder: source
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
 # render the recipe correctly
 requirements:
   host:
-    - python >=3.6
+    - python
 
 outputs:
   - name: flit-core
@@ -27,7 +27,7 @@ outputs:
       noarch: python
     requirements:
       host:
-        - python >=3.6
+        - python
         - pip
       run:
         - python >=3.6
@@ -36,6 +36,11 @@ outputs:
       imports:
         - flit_core
         - flit_core.common
+      requires:
+        - pip
+        - python <3.10
+      commands:
+        - pip check
 
   - name: flit
     version: {{ version }}
@@ -46,7 +51,7 @@ outputs:
         - flit = flit:main
     requirements:
       host:
-        - python >=3.6
+        - python
         - pip
         - docutils
         - requests
@@ -58,13 +63,16 @@ outputs:
         - pip
         - docutils
         - requests
-        - requests_download
         - toml
         - {{ pin_subpackage('flit-core', exact=True) }}
     test:
       imports:
         - flit
+      requires:
+        - pip
+        - python <3.10
       commands:
+        - pip check
         - flit --version
 
 about:
@@ -73,6 +81,8 @@ about:
   license_family: BSD
   license_file: source/LICENSE
   summary: Simplified packaging of Python modules
+  dev_url: https://github.com/takluyver/flit
+  doc_url: https://flit.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update flit to 3.3.0

To build python-build we need to add a chain of dependencies: `python-build 0.7.0` <- `pep517 >=0.12.0` <- `tomli 1.2.2` <- `flit` `(flit-core ==3.3.0`)

Version change: bump version number from 3.2.0 to 3.3.0
PyPi: https://pypi.org/project/flit/#history
Bug Tracker: new open issues https://github.com/takluyver/flit/issues
Upstream license: https://github.com/takluyver/flit/blob/master/LICENSE
Upstream changelog: https://flit.readthedocs.io/en/latest/history.html
Upstream setup files:
- flit: https://github.com/takluyver/flit/blob/3.3.0/pyproject.toml
- flit-core https://github.com/takluyver/flit/blob/3.3.0/flit_core/pyproject.toml and https://github.com/takluyver/flit/blob/3.3.0/flit_core/flit_core/build_thyself.py

The package flit is mentioned inside the packages:
aioitertools | backcall | confuse | jeepney | pep517 | ptyprocess | testpath | threadpoolctl | typer |

Actions:
1. Update dependencies
2. Fix python
3. Add dev, doc urls

Result:
- all-succeeded