### PR TITLE
flit 3.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,10 @@ outputs:
         - pip
         - docutils
         - requests
+        - setuptools
         - tomli
         - tomli-w
+        - wheel
         - {{ pin_subpackage('flit-core', exact=True) }}
       run:
         - python >=3.6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.6.0" %}
+{% set version = "3.3.0" %}
 
 package:
   name: flit-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flit/flit-{{ version }}.tar.gz
-  sha256: b1464e006df4df4c8eeb37671c0e0ce66e1d04e4a36d91b702f180a25fde3c11
+  sha256: 65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57
   folder: source
 
 build:
@@ -31,7 +31,6 @@ outputs:
         - pip
       run:
         - python >=3.6
-        - toml
     test:
       imports:
         - flit_core
@@ -55,15 +54,16 @@ outputs:
         - pip
         - docutils
         - requests
-        - requests_download
-        - toml
+        - tomli
+        - tomli-w
         - {{ pin_subpackage('flit-core', exact=True) }}
       run:
         - python >=3.6
         - pip
         - docutils
         - requests
-        - toml
+        - tomli
+        - tomli-w
         - {{ pin_subpackage('flit-core', exact=True) }}
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.0" %}
+{% set version = "3.6.0" %}
 
 package:
   name: flit-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flit/flit-{{ version }}.tar.gz
-  sha256: 65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57
+  sha256: b1464e006df4df4c8eeb37671c0e0ce66e1d04e4a36d91b702f180a25fde3c11
   folder: source
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.3.0" %}
+{% set version = "3.6.0" %}
 
 package:
   name: flit-core
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/f/flit/flit-{{ version }}.tar.gz
-  sha256: 65fbe22aaa7f880b776b20814bd80b0afbf91d1f95b17235b608aa256325ce57
+  sha256: b1464e006df4df4c8eeb37671c0e0ce66e1d04e4a36d91b702f180a25fde3c11
   folder: source
 
 build:
@@ -23,12 +23,14 @@ outputs:
   - name: flit-core
     version: {{ version }}
     build:
-      script: python -m pip install --no-deps -vv source/flit_core/
+      script: {{ PYTHON }} -m pip install --no-deps -vv source/flit_core/
       noarch: python
     requirements:
       host:
         - python
         - pip
+        - setuptools
+        - wheel
       run:
         - python >=3.6
     test:
@@ -37,7 +39,6 @@ outputs:
         - flit_core.common
       requires:
         - pip
-        - python <3.10
       commands:
         - pip check
 
@@ -70,7 +71,6 @@ outputs:
         - flit
       requires:
         - pip
-        - python <3.10
       commands:
         - pip check
         - flit --version


### PR DESCRIPTION
Update flit to 3.6.0

Bug tracker: https://github.com/pypa/flit/issues
Changelog: https://github.com/pypa/flit/blob/3.6.0/doc/history.rst
License: https://github.com/pypa/flit/blob/3.6.0/LICENSE
flit pyproject.toml: https://github.com/pypa/flit/blob/3.6.0/pyproject.toml
flit_core pyproject.toml: https://github.com/pypa/flit/blob/3.6.0/flit_core/pyproject.toml

Actions:
1. Add missing `host` dependencies: `setuptools`, `wheel`
2. Remove `python <3.10` from test/requires