### PR TITLE
rebuild `flit-core` version `3.6` to correct issue with `tomli` missing

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,8 @@ outputs:
   - name: flit
     version: {{ version }}
     build:
-      # there is an error with FLIT_ROOT_INSTALL on windows
       script: cd source/ && FLIT_ROOT_INSTALL=1 python -m flit install --deps=none  # [not win]
-      script: cd source/ && python -m flit install --deps=none  # [win]
+      script: cd source/ && python -m flit install --deps=none  # [win]  # this solves the win build error 
       noarch: python
       entry_points:
         - flit = flit:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,16 +29,12 @@ outputs:
       host:
         - python
         - pip
-        - docutils
-        - requests
         - setuptools
         - tomli
         - tomli-w
         - wheel
       run:
         - python >=3.6
-        - docutils
-        - requests
         - tomli
         - tomli-w
     test:
@@ -53,9 +49,7 @@ outputs:
   - name: flit
     version: {{ version }}
     build:
-      # there is an error with FLIT_ROOT_INSTALL on windows, the solution is to remove this section
-      # there is some information on this  on the following issue https://github.com/pypa/flit/issues/487
-      # in addition on this item: https://flit.pypa.io/en/latest/cmdline.html#envvar-FLIT_ROOT_INSTALL
+      # there is an error with FLIT_ROOT_INSTALL on windows
       script: cd source/ && FLIT_ROOT_INSTALL=1 python -m flit install --deps=none  # [not win]
       script: cd source/ && python -m flit install --deps=none  # [win]
       noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 # Specifying `python` as a top-level build requirements to force conda to
 # render the recipe correctly
@@ -30,9 +30,13 @@ outputs:
         - python
         - pip
         - setuptools
+        - tomli
+        - tomli-w
         - wheel
       run:
         - python >=3.6
+        - tomli
+        - tomli-w
     test:
       imports:
         - flit_core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ about:
   license_family: BSD
   license_file: source/LICENSE
   summary: Simplified packaging of Python modules
-  dev_url: https://github.com/takluyver/flit
+  dev_url: https://github.com/pypa/flit
   doc_url: https://flit.readthedocs.io/en/latest/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,11 @@ outputs:
   - name: flit
     version: {{ version }}
     build:
-      script: cd source/ && FLIT_ROOT_INSTALL=1 python -m flit install --deps=none
+      # there is an error with FLIT_ROOT_INSTALL on windows, the solution is to remove this section
+      # there is some information on this  on the following issue https://github.com/pypa/flit/issues/487
+      # in addition on this item: https://flit.pypa.io/en/latest/cmdline.html#envvar-FLIT_ROOT_INSTALL
+      script: cd source/ && FLIT_ROOT_INSTALL=1 python -m flit install --deps=none  # [not win]
+      script: cd source/ && python -m flit install --deps=none  # [win]
       noarch: python
       entry_points:
         - flit = flit:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,12 +29,16 @@ outputs:
       host:
         - python
         - pip
+        - docutils
+        - requests
         - setuptools
         - tomli
         - tomli-w
         - wheel
       run:
         - python >=3.6
+        - docutils
+        - requests
         - tomli
         - tomli-w
     test:


### PR DESCRIPTION
rebuild `flit-core` version `3.6` to correct issue with package missing `tomli`.
This is needed to build `pyparsing`.

---


Rebuild `flit` version `3.6.0`
1. - [x] Check the upstream
    https://github.com/pypa/flit/tree/3.6.0

2. - [x] Check the pinnings

    The dependencies for `flit_core` are not very explicit in some files
    https://github.com/pypa/flit/blob/3.6.0/flit_core/pyproject.toml#L12
    https://github.com/pypa/flit/blob/3.6.0/flit_core/update-vendored-tomli.sh#L9

    The package has `tomli` and `tomli-w` as a dependency
    https://github.com/pypa/flit/blob/3.6.0/pyproject.toml#L14&&L15

    The package has `docutils` as a dependency
    https://github.com/pypa/flit/blob/3.6.0/pyproject.toml#L13

    The package has `request` as a dependency
    https://github.com/pypa/flit/blob/3.6.0/pyproject.toml#L12

3. - [x] Check the changelogs
    https://github.com/pypa/flit/blob/3.6.0/doc/history.rst

4. - [x] Additional research
    https://github.com/conda-forge/flit-feedstock/issues

    currently there are no significant open issues mentined in the upstream at the time of the review

5. - [x] Verify the `dev_url`
    https://github.com/takluyver/flit

    redirect to:
    (https://github.com/pypa/flit)

6. - [x] Verify the `doc_url`
    https://flit.readthedocs.io/en/latest

7. - [x] License is `spdx` compliant
    BSD-3-Clause

8. - [x] License family is present
    BSD
9. - [x] Verify that the `build_number` is correct

    increase the build number since the package is a rebuild

10. - [x] Verify if the package needs `setuptools`

    `setuptools` is part of the recipe as a host requirement

11. - [x] Verify if the package needs `wheel`

    `wheel` is part of the recipe as a host requirement

12. - [x] `pip` in the test section

    - pip is in the test section

13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`

    This package is a `noarch` while we no longer build `noarch` packages this is a rebuild.
    Since there is a package that has the same version, it will be wise to keep both versions as close to each other as possible. 
    In this context it will be wise to keep the package as a `noarch`.

15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)

Results:
-


Based on the research findings and the results we can conclude
that it is save to rebuild `flit` version `3.6.0`
