### PR TITLE
Make flit-core bootstrapable without setuptools and wheel

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 # When building out the initial package set for a new Python version the
 # recommendation is to build flit-core first.
-# If boostsrap: yes, build flit-core only; otherwise build all the outputs.
-boostsrap: no
+# If bootstrap: yes, build flit-core only; otherwise build all the outputs.
+bootstrap: no

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,8 +42,8 @@ outputs:
 
   # When building out the initial package set for a new Python version the
   # recommendation is to build flit-core first.
-  # If boostsrap: yes, build flit-core only; otherwise build all the outputs.
-  {% if boostsrap != 'yes' %}
+  # If bootstrap: yes, build flit-core only; otherwise build all the outputs.
+  {% if bootstrap != 'yes' %}
   - name: flit
     version: {{ version }}
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,10 @@ outputs:
     version: {{ version }}
     build:
       script:
+        # flit-core is a core python dependency and it used to bootstrap the whole packaging ecosystem.
+        # Because of that, it cannot depend on anything except python itself.
+        # We can't use pip because to build pip, we need setuptools and wheel. wheel requires flit-core.
+        # So flit-core is "self-hosting" and provides its own build and install methods.
         - cd source/flit_core && {{ PYTHON }} -m flit_core.wheel
         - {{ PYTHON }} bootstrap_install.py dist/flit_core-{{ version }}-py3-none-any.whl
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   folder: source
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<36]
 
 # Specifying `python` as a top-level build requirements to force conda to
@@ -23,13 +23,12 @@ outputs:
   - name: flit-core
     version: {{ version }}
     build:
-      script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv source/flit_core/
+      script:
+        - cd source/flit_core && {{ PYTHON }} -m flit_core.wheel
+        - {{ PYTHON }} bootstrap_install.py dist/flit_core-{{ version }}-py3-none-any.whl
     requirements:
       host:
         - python
-        - pip
-        - setuptools
-        - wheel
       run:
         - python
     test:
@@ -60,9 +59,7 @@ outputs:
         - pip
         - docutils
         - requests
-        - setuptools
         - tomli-w
-        - wheel
         - {{ pin_subpackage('flit-core', exact=True) }}
       run:
         - python


### PR DESCRIPTION
flit-core 3.9.0 build 1

**Destination channel:** defaults

### Explanation of changes:

`flit-core` is a very core package of the ecosystem and it we can't depend on setuptools, pip or wheel to build it. It's designed specifically to be bootstrapable without anything except python. This is very important for the python ecosystem.

So this PR makes flit-core dependency less.
