### PR TITLE
Bumped the version to 3.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set version = "3.9.0" %}
+{% set version = "3.12.0" %}
 
 package:
   name: flit-suite
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/f/flit/flit-{{ version }}.tar.gz
-  sha256: d75edf5eb324da20d53570a6a6f87f51e606eee8384925cd66a90611140844c7
+  url: https://pypi.org/packages/source/f/flit/flit-{{ version }}.tar.gz
+  sha256: 1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740
   folder: source
 
 build:
-  number: 1
-  skip: True  # [py<36]
+  number: 0
+  skip: True  # [py<38]
 
 # Specifying `python` as a top-level build requirements to force conda to
 # render the recipe correctly
@@ -33,6 +33,8 @@ outputs:
     requirements:
       host:
         - python
+        - wheel
+        - setuptools
       run:
         - python
     test:
@@ -73,19 +75,38 @@ outputs:
         - tomli-w
         - {{ pin_subpackage('flit-core', exact=True) }}
     test:
+      source_files:
+        - source/tests
+        - source/pyproject.toml
       imports:
         - flit
         - flit.build
       requires:
         - pip
+        - pytest >=2.7.3
+        - testpath
+        - responses
         - ripgrep
       commands:
         - pip check
+        - echo ON  # [win]
         - flit --version | rg {{ version }}
+        - cd source && pytest tests -v -p no:warnings # [not linux]
+        - cd source && pytest tests -v \
+          --deselect=tests/test_build.py::test_build_main \
+          --deselect=tests/test_build.py::test_build_sdist_only \
+          --deselect=tests/test_build.py::test_build_ns_main \
+          --deselect=tests/test_install.py::InstallTests::test_install_requires \
+          --deselect=tests/test_install.py::InstallTests::test_symlink_other_python \
+          --deselect=tests/test_install.py::InstallTests::test_pip_install \
+          --deselect=tests/test_install.py::test_install_requires_extra \
+          --deselect=tests/test_install.py::test_test_writable_dir_win \
+          --deselect=tests/test_sdist.py::test_get_files_list_git \
+          --deselect=tests/test_sdist.py::test_get_files_list_hg  # [linux]
   {% endif %}
 
 about:
-  home: https://flit.pypa.io/en/stable/
+  home: https://flit.pypa.io
   license: BSD-3-Clause
   license_family: BSD
   license_file: source/LICENSE
@@ -95,7 +116,7 @@ about:
     It tries to require less thought about packaging and helps avoid 
     common mistakes. 
   dev_url: https://github.com/takluyver/flit
-  doc_url: https://flit.pypa.io/en/latest/
+  doc_url: https://flit.pypa.io
 
 extra:
   recipe-maintainers:
@@ -103,3 +124,5 @@ extra:
     - minrk
     - takluyver
     - ocefpaf
+  skip-lints:
+    - wrong_output_script_key


### PR DESCRIPTION
flit 3.12

**Destination channel:** defaults

### Links

- [PKG-9036](https://anaconda.atlassian.net/browse/PKG-9036)
- [Upstream repository](https://github.com/pypa/flit/tree/main)
- dev_url:        https://github.com/pypa/flit/tree/3.12.0
- conda_forge:    https://github.com/conda-forge/flit-feedstock
- pypi:           https://pypi.org/project/flit/3.12.0
- pypi inspector: https://inspector.pypi.io/project/flit/3.12.0/

### Explanation of changes:

- Was not able to resolve linter issues due to unfamiliarity
- Added DeprectaionWarning suppression due to Win platform
- Skipped test for linux platform due to them trying to treat .tar as git repository

[PKG-9036]: https://anaconda.atlassian.net/browse/PKG-9036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ