### PR TITLE
Rebuild without wheel and setuptools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,7 +114,7 @@ about:
     Flit is a simple way to put Python packages and modules on PyPI.
     It tries to require less thought about packaging and helps avoid
     common mistakes.
-  dev_url: https://github.com/takluyver/flit
+  dev_url: https://github.com/pypa/flit
   doc_url: https://flit.pypa.io
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<38]
 
 # Specifying `python` as a top-level build requirements to force conda to
@@ -32,8 +32,6 @@ outputs:
     requirements:
       host:
         - python
-        - wheel
-        - setuptools
       run:
         - python
     test:


### PR DESCRIPTION
flit 3.12.0

**Destination channel:**  defaults

### Links

- [PKG-12588](https://anaconda.atlassian.net/browse/PKG-12588) 
- [Upstream repository](https://github.com/pypa/flit/tree/3.12.0)

### Explanation of changes:
- Rebuild without wheel in dependencies to avoid cycle dependency


[PKG-12588]: https://anaconda.atlassian.net/browse/PKG-12588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ